### PR TITLE
Fix pip package version conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     url='https://github.com/SD4RK/epicstore_api',
     license='MIT',
     include_package_data=True,
-    install_requires=['requests==2.25.1'],
+    install_requires=['requests>=2.25.1'],
     download_url=f'https://github.com/SD4RK/epicstore_api/archive/v_{VERSION}.tar.gz',
     packages=setuptools.find_packages(),
     classifiers=[


### PR DESCRIPTION
Fixing this:

```shell
2022-10-24 02:32:01.760 ERROR (SyncWorker_4) [homeassistant.util.package] Unable to install package epicstore-api==0.1.3: ERROR: Cannot install epicstore-api==0.1.3 because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

versions:
- python 3.10
- pip 22.3