### PR TITLE
Add much more details to the free games example

### DIFF
--- a/examples/free_games_example.py
+++ b/examples/free_games_example.py
@@ -6,8 +6,20 @@ def main():
     """Fetches current free games from the store."""
     api = EpicGamesStoreAPI()
     free_games = api.get_free_games()['data']['Catalog']['searchStore']['elements']
+
+    # Few odd items do not seems game and don't have the promotion attribute, so let's check it !
+    free_games = list(sorted(
+        filter(
+            lambda g: g.get('promotions'),
+            free_games
+        ),
+        key=lambda g: g['title']
+    ))
+
     for game in free_games:
-        game_name = game['title']
+        game_title = game['title']
+        game_publisher = game['seller']['name']
+        game_url = f"https://store.epicgames.com/fr/p/{game['catalogNs']['mappings'][0]['pageSlug']}"
         game_thumbnail = None
         # Can be useful when you need to also show the thumbnail of the game.
         # Like in Discord's embeds for example, or anything else.
@@ -15,31 +27,53 @@ def main():
         for image in game['keyImages']:
             if image['type'] == 'Thumbnail':
                 game_thumbnail = image['url']
+
         game_price = game['price']['totalPrice']['fmtPrice']['originalPrice']
-        try:
-            game_promotions = game['promotions']['promotionalOffers']
-            upcoming_promotions = game['promotions']['upcomingPromotionalOffers']
-            if not game_promotions and upcoming_promotions:
-                # Promotion is not active yet, but will be active soon.
-                promotion_data = upcoming_promotions[0]['promotionalOffers'][0]
-                start_date_iso, end_date_iso = (
-                    promotion_data['startDate'][:-1], promotion_data['endDate'][:-1]
-                )
-                # Remove the last "Z" character so Python's datetime can parse it.
-                start_date = datetime.fromisoformat(start_date_iso)
-                end_date = datetime.fromisoformat(end_date_iso)
-                print('{} ({}) will be free from {} to {} UTC.'.format(
-                    game_name, game_price, start_date, end_date
-                ))
-            else:
-                print('{} ({}) is FREE now.'.format(
-                    game_name, game_price
-                ))
-        except TypeError:
-            pass
-            # or
-            #print('No discounts for this game')
-            # your choice
+        game_price_promo = game['price']['totalPrice']['fmtPrice']['discountPrice']
+
+        game_promotions = game['promotions']['promotionalOffers']
+        upcoming_promotions = game['promotions']['upcomingPromotionalOffers']
+
+        if game_promotions and game['price']['totalPrice']['discountPrice'] == 0:
+            # Promotion is active.
+            promotion_data = game_promotions[0]['promotionalOffers'][0]
+            start_date_iso, end_date_iso = (
+                promotion_data['startDate'][:-1], promotion_data['endDate'][:-1]
+            )
+            # Remove the last "Z" character so Python's datetime can parse it.
+            start_date = datetime.fromisoformat(start_date_iso)
+            end_date = datetime.fromisoformat(end_date_iso)
+            print('* {} ({}) is FREE now, until {} --> {}'.format(
+                game_title, game_price, end_date, game_url
+            ))
+        elif not game_promotions and upcoming_promotions:
+            # Promotion is not active yet, but will be active soon.
+            promotion_data = upcoming_promotions[0]['promotionalOffers'][0]
+            start_date_iso, end_date_iso = (
+                promotion_data['startDate'][:-1], promotion_data['endDate'][:-1]
+            )
+            # Remove the last "Z" character so Python's datetime can parse it.
+            start_date = datetime.fromisoformat(start_date_iso)
+            end_date = datetime.fromisoformat(end_date_iso)
+            print('* {} ({}) will be free from {} to {} UTC --> {}'.format(
+                game_title, game_price, start_date, end_date, game_url
+            ))
+        elif game_promotions:
+            # Promotion is active.
+            promotion_data = game_promotions[0]['promotionalOffers'][0]
+            start_date_iso, end_date_iso = (
+                promotion_data['startDate'][:-1], promotion_data['endDate'][:-1]
+            )
+            # Remove the last "Z" character so Python's datetime can parse it.
+            start_date = datetime.fromisoformat(start_date_iso)
+            end_date = datetime.fromisoformat(end_date_iso)
+            print('* {} is in promotion ({} -> {}) from {} to {} UTC --> {}'.format(
+                game_title, game_price, game_price_promo, start_date, end_date, game_url
+            ))
+        else:
+            print('* {} is always free --> {}'.format(
+                game_title, game_url
+            ))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- remove useless try-catch usage (from #11)
- improve logs
- separate current free/next free/always free/promos games


Current output logs
```shell
* A Game Of Thrones: The Board Game Digital Edition is in promotion ($19.99 -> $13.99) from 2022-10-18 15:00:00 to 2022-11-01 15:00:00 UTC --> https://store.epicgames.com/fr/p/a-game-of-thrones-5858a3
* Fallout 3: Game of the Year Edition is in promotion ($19.99 -> $6.59) from 2022-10-27 15:00:00 to 2022-11-01 15:00:00 UTC --> https://store.epicgames.com/fr/p/fallout-3-game-of-the-year-edition
* Filament ($16.99) will be free from 2022-11-03 15:00:00 to 2022-11-10 16:00:00 UTC --> https://store.epicgames.com/fr/p/filament-332a92
* Idle Champions of the Forgotten Realms is always free --> https://store.epicgames.com/fr/p/idle-champions-of-the-forgotten-realms
* Rising Storm 2: Vietnam ($24.99) will be free from 2022-11-03 15:00:00 to 2022-11-10 16:00:00 UTC --> https://store.epicgames.com/fr/p/rising-storm-2-vietnam
* Saturnalia ($19.99) is FREE now, until 2022-11-03 15:00:00 --> https://store.epicgames.com/fr/p/saturnalia
* Shadow of the Tomb Raider: Definitive Edition is in promotion ($39.99 -> $13.19) from 2022-10-18 15:00:00 to 2022-11-01 15:00:00 UTC --> https://store.epicgames.com/fr/p/shadow-of-the-tomb-raider
* Terraforming Mars is in promotion ($19.99 -> $13.99) from 2022-10-18 15:00:00 to 2022-11-01 15:00:00 UTC --> https://store.epicgames.com/fr/p/terraforming-mars-18c3ad
* Warhammer 40,000: Mechanicus - Standard Edition ($29.99) is FREE now, until 2022-11-03 15:00:00 --> https://store.epicgames.com/fr/p/warhammer-mechanicus-0e4b71
```