### PR TITLE
Minor refurbishment

### DIFF
--- a/epicstore_api/api.py
+++ b/epicstore_api/api.py
@@ -204,7 +204,7 @@ class EpicGamesStoreAPI:
         except EGSNotFound as exc:
             exc.message = (
                 'There are no reviews for this product, '
-                'or the given sku ({}) is incorrect.'.format(product_sku)
+                f'or the given sku ({product_sku}) is incorrect.'
             )
             raise
 

--- a/epicstore_api/exc.py
+++ b/epicstore_api/exc.py
@@ -30,7 +30,7 @@ class EGSException(Exception):
     Class for EGS errors, all data about error is placed in ``exception_data``
     """
     def __init__(self, message, error_code=None, service_response=None):
-        super(EGSException, self).__init__(message)
+        super().__init__(message)
         self.message = (
             f'Error code: '
             f'{error_code if error_code is not None else "unknown"}. '

--- a/examples/free_games_example.py
+++ b/examples/free_games_example.py
@@ -43,9 +43,7 @@ def main():
             # Remove the last "Z" character so Python's datetime can parse it.
             start_date = datetime.fromisoformat(start_date_iso)
             end_date = datetime.fromisoformat(end_date_iso)
-            print('* {} ({}) is FREE now, until {} --> {}'.format(
-                game_title, game_price, end_date, game_url
-            ))
+            print(f'* {game_title} ({game_price}) is FREE now, until {end_date} --> {game_url}')
         elif not game_promotions and upcoming_promotions:
             # Promotion is not active yet, but will be active soon.
             promotion_data = upcoming_promotions[0]['promotionalOffers'][0]
@@ -55,9 +53,7 @@ def main():
             # Remove the last "Z" character so Python's datetime can parse it.
             start_date = datetime.fromisoformat(start_date_iso)
             end_date = datetime.fromisoformat(end_date_iso)
-            print('* {} ({}) will be free from {} to {} UTC --> {}'.format(
-                game_title, game_price, start_date, end_date, game_url
-            ))
+            print(f'* {game_title} ({game_price}) will be free from {start_date} to {end_date} UTC --> {game_url}')
         elif game_promotions:
             # Promotion is active.
             promotion_data = game_promotions[0]['promotionalOffers'][0]
@@ -67,13 +63,9 @@ def main():
             # Remove the last "Z" character so Python's datetime can parse it.
             start_date = datetime.fromisoformat(start_date_iso)
             end_date = datetime.fromisoformat(end_date_iso)
-            print('* {} is in promotion ({} -> {}) from {} to {} UTC --> {}'.format(
-                game_title, game_price, game_price_promo, start_date, end_date, game_url
-            ))
+            print(f'* {game_title} is in promotion ({game_price} -> {game_price_promo}) from {start_date} to {end_date} UTC --> {game_url}')
         else:
-            print('* {} is always free --> {}'.format(
-                game_title, game_url
-            ))
+            print(f'* {game_title} is always free --> {game_url}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

- [`pylint`](https://github.com/PyCQA/pylint)

> **Note** C0209
> Formatted string literals (f-strings) give a concise, consistent syntax that can replace most use cases `str.format()`.

---

- [`pyupgrade`](https://github.com/asottile/pyupgrade):

### `super()` calls

```diff
 class C(Base):
     def f(self):
-        super(C, self).f()
+        super().f()
```