### PR TITLE
Update `get_free_games()` to use self._session

### DIFF
--- a/epicstore_api/api.py
+++ b/epicstore_api/api.py
@@ -93,7 +93,7 @@ class EpicGamesStoreAPI:
             'freeGamesPromotions?locale={}&country={}&allowCountries={}'
         )
         api_uri = api_uri.format(self.locale, self.country, allow_countries)
-        data = requests.get(api_uri).json()
+        data = self._session.get(api_uri).json()
         self._get_errors(data)
         return data
 


### PR DESCRIPTION
Currently, `get_free_games()` does not use a user-provided session and makes users unable to pass the `proxies`, `user-agent` and etc. settings.

This PR would fix that.