### PR TITLE
Fix game url so free_games_example.py can run

### DIFF
--- a/examples/free_games_example.py
+++ b/examples/free_games_example.py
@@ -18,7 +18,11 @@ def main() -> None:
     for game in free_games:
         game_title = game['title']
         game_publisher = game['seller']['name']
-        game_url = f"https://store.epicgames.com/fr/p/{game['catalogNs']['mappings'][0]['pageSlug']}"
+
+        url_type = "bundles" if game['offerType'] == "BUNDLE" else "p"
+        final_slug = game["catalogNs"]["mappings"][0]["pageSlug"] if game["catalogNs"]["mappings"] else game["urlSlug"]
+        game_url = f"https://store.epicgames.com/fr/{url_type}/{final_slug}"
+
         # Can be useful when you need to also show the thumbnail of the game.
         # Like in Discord's embeds for example, or anything else.
         # Here I showed it just as example and won't use it.


### PR DESCRIPTION
Removed existing line of code for game url, which was causing a crash due to game['catalogNs']['mappings'][0]['pageSlug'] sometimes returning 'NoneType' object. In my solution, if this happens, it takes game["urlSlug"] instead, which in the majority of cases is used by the online store as the url slug.

The url also changes according to whether the game is a standalone or part of a bundle; for example, the link to Fallout Classic Collection recently didn't work, as the example produced the url https://store.epicgames.com/fr/p/fallout-classic-collection (a dead link) rather than the actual one: https://store.epicgames.com/fr/bundles/fallout-classic-collection. This can be solved by checking if game['offerType'] returns 'BUNDLE' or not.
